### PR TITLE
Set constant versions so that docker build succeeds

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,7 +1,7 @@
 version: '3'
 services:
   mongo:
-    image: mongo:latest
+    image: mongo:4.2.23
     volumes: 
       - ./db:/data/db
     environment:

--- a/flintapp/Dockerfile
+++ b/flintapp/Dockerfile
@@ -1,5 +1,9 @@
 FROM node:8-alpine
 
+ENV NODE_TLS_REJECT_UNAUTHORIZED=0
+RUN apk add --update python make g++\
+   && rm -rf /var/cache/apk/*
+
 WORKDIR /usr/src/app
 
 COPY package*.json ./


### PR DESCRIPTION
The repo was broken because it uses 'mongo:latest' image which doesn't support the commands that the vuln abuses.
Moreover, the python env needed to be explicitly declared and TLS outdate ignored.

